### PR TITLE
add a readme with a quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Signalo OAPIF
+
+## Quickstart
+
+```
+# copy default conf
+cp .env.example .env
+
+# start the stack
+docker compose up --build -d
+
+# load fixtures (takes ~30s)
+docker compose exec django python manage.py loaddata pole.json sign.json
+
+# refresh computed fields (takes ~1min)
+docker compose exec django python manage.py updatedata
+
+# wait a little, then check that https://localhost/oapif/collections/poles/items works from your browser
+```
+
+## Use from QGIS
+
+Once up and running, you can use it from QGIS like this:
+
+- Go to `Layers` > `Add layer` > `Add WFS Layer...`
+- Create a new connection
+  - URL: `https://localhost/oapif/`
+  - Version: `OGC API - Features`
+- Click OK and ignore choose to ignore the invalid certificate error and store the exception
+- You should see the two layers in the list, select them and choose `add`.


### PR DESCRIPTION
Note that here it doesn't fully work from QGIS:
- connecting through https doesn't fully work (e.g. the "Detect version" button fails with `Download of API page failed: Cannot decode JSON document: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'o'`). Seems to work better when connecting directoy to django: http://localhost:8000/oapif/
- the sign layers doesn't work (`Cannot open /vsimem/oaipf_0000007842797608.json (Failed to read GeoJSON data).(Failed to read GeoJSON data)` in the logs)
- even if the pole layer seems to work, I get some errors (`Download of features for layer poles failed or partially failed: Download of items failed: Protocol "" is unknown. You may attempt reloading the layer with F5`)
- there seem to be some mixups of coordinates (unless the signalo project is in Ethiopia :-) )