### PR TITLE
improve docker-compose management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # MAIN SETTINGS FOR THE DOCKER COMPOSE STACK
 
+# Change which dockerfiles to include. In production, make sure to only include docker-compose.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.tests.yml:docker-compose.dev.yml
+
 # Change this to the host name on which the stack is installed
 SIGNALO_HOST=localhost
 
@@ -14,3 +17,6 @@ TX_TOKEN=_change_me_
 
 # Geometry's SRID. This can only be changed prior to initializing the database.
 GEOMETRY_SRID=2056
+
+# (cross-platform compatibility, do not change)
+COMPOSE_FILE_SEPARATOR=:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       run: wget --no-check-certificate https://localhost/oapif/collections/signalo_core.pole/items
 
     - name: Run conformance test suite
-      run: docker compose -f docker-compose.tests.yml up --build conformance_test
+      run: docker compose up --build conformance_test
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once up and running, you can use it from QGIS like this:
 You can run the OGC API conformance test suite like this:
 
 ```
-docker compose -f docker-compose.tests.yml up --build conformance_test
+docker compose up --build conformance_test
 ```
 
 Results will be stored to `_test_outputs\testng\...\emailable-report.html

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,6 @@
+# overrides for local developpement (mounts the source, enables debug, live-reload, etc.)
+# DO NOT USE ON PRODUCTION !!!
+
 version: '3.7'
 
 services:

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,3 +1,5 @@
+# overrides for running tests
+
 services:
 
   conformance_test:
@@ -5,3 +7,5 @@ services:
     volumes:
       - ./_test_outputs:/build/run/output
       # - .:/build/run/test-run-props.xml
+    profiles:
+      - testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# default stack
+
 version: '3.7'
 
 services:


### PR DESCRIPTION
- use COMPOSE_FILE in .env to pick which docker-compose files to include (allowing for local overrides if needed)
- add profiles to not run conformance-test container on docker-compose up


(make sure to update your local copy of .env)